### PR TITLE
use specific hash for gh-actions versions

### DIFF
--- a/.github/actions/setup-and-test/action.yml
+++ b/.github/actions/setup-and-test/action.yml
@@ -11,12 +11,12 @@ runs:
   using: 'composite'
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061# v4
       with:
         version: 9.15.0
 
     - name: Use Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: 24.x
         registry-url: ${{ inputs.registry-url || '' }}
@@ -37,7 +37,7 @@ runs:
 
     - name: Cache Playwright browsers
       id: playwright-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.cache/ms-playwright
         key: playwright-${{ runner.os }}-${{ env.PLAYWRIGHT_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main'
+    if: github.ref != 'refs/heads/main
     steps:
       - name: Checkout all commits
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
 
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout all commits
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
 
@@ -59,7 +59,7 @@ jobs:
       - name: Create Release Pull Request or Publish
         if: github.ref == 'refs/heads/main'
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         with:
           publish: pnpm release
         env:


### PR DESCRIPTION
## 🔒 Security: Pin GitHub Actions to commit SHAs

### Summary
Replaced all GitHub Actions version tags (e.g., `@v3`, `@v4`) with specific commit hashes to enhance workflow security and prevent potential supply chain attacks.

### Why?
Version tags are mutable and can be moved to point to different commits. Pinning to immutable commit hashes ensures workflows always execute the exact, reviewed code, protecting against:
- Compromised action repositories
- Malicious tag updates
- Unintended breaking changes

### Verification
All commit hashes have been verified against their respective repository tags. Comments preserve original version numbers for reference.

