### PR TITLE
deprecate setup-zones in favour of analog's setupTestBed

### DIFF
--- a/.changeset/petite-spoons-beam.md
+++ b/.changeset/petite-spoons-beam.md
@@ -1,0 +1,29 @@
+---
+'vitest-browser-angular': minor
+---
+
+FEAT: deprecate `setup-zones` in favor of analog's setupTestBed
+
+**Motivation**
+
+Analog has implemented their own `setupTestBed()` function that provides a more comprehensive and maintained solution for setting up Angular tests with Vitest.
+
+Rather than maintaining duplicate setup logic and keeping documentation in sync, we're directing users to Analog's official documentation.
+
+**Migration Guide**
+
+Users should migrate from:
+
+```ts
+// vitest.config.ts
+
+setupFiles: ['vitest-browser-angular/setup-zones'];
+```
+
+To using Analog's `setupTestBed()`:
+
+```ts
+setupTestBed({ browserMode: true });
+```
+
+See https://analogjs.org/docs/features/testing/vitest for full instructions

--- a/.changeset/some-gifts-sin.md
+++ b/.changeset/some-gifts-sin.md
@@ -1,0 +1,5 @@
+---
+'vitest-browser-angular': patch
+---
+
+FIX: component type in render function

--- a/.changeset/tidy-views-dress.md
+++ b/.changeset/tidy-views-dress.md
@@ -1,10 +1,5 @@
 ---
-'vitest-browser-angular': minor
+'vitest-browser-angular': patch
 ---
 
-Implemented configuration for zoneless with a new setup file (`setup-zoneless.ts`)
-
-- Added specific config for zoneless vitest for run specific set of tests
-- Modified `setupAngularTestEnvironment` to accept a parameter for zoneless setup (by default setted to true for v21+)
-- Updated README with zoneless setup instructions
-- Implemented tests for zoneless setup
+INFRA: Implemented tests for zoneless setup

--- a/README.md
+++ b/README.md
@@ -8,51 +8,13 @@ Render Angular components in VItest Browser Mode.
 pnpm add -D vitest-browser-angular
 ```
 
-## Setup Test Environment with Zone.js
+## Setup Test Environment
 
-```ts
-// vitest.config.ts
+To set up your test environment (with Zone.js or Zoneless), use `@analogjs/vitest-angular`'s `setupTestBed()` function.
 
-import { playwright } from '@vitest/browser-playwright';
+**Important:** Make sure to use `{ browserMode: true }` when calling `setupTestBed()` to enable Vitest browser mode's visual test preview functionality.
 
-export default defineConfig({
-  test: {
-    globals: true,
-
-    // 👇 This is what you need to add
-    setupFiles: ['vitest-browser-angular/setup-zones'],
-
-    browser: {
-      enabled: true,
-      provider: playwright(),
-      instances: [{ browser: 'chromium' }],
-    },
-  },
-});
-```
-
-## Setup Test Environment with Zoneless
-
-```ts
-// vitest.config.ts
-
-import { playwright } from '@vitest/browser-playwright';
-
-export default defineConfig({
-  test: {
-    globals: true,
-
-    // 👇 This is what you need to add
-    setupFiles: ['vitest-browser-angular/setup-zoneless'],
-
-    browser: {
-      enabled: true,
-      provider: playwright(),
-      instances: [{ browser: 'chromium' }],
-    },
-  },
-});
-```
+For detailed setup instructions for both Zone.js and Zoneless configurations, please refer to the [Analog Vitest documentation](https://analogjs.org/docs/features/testing/vitest).
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -58,17 +58,14 @@
     "test": "vitest"
   },
   "peerDependencies": {
-    "@analogjs/vitest-angular": "^1.20.0",
-    "@angular/compiler": "^20.0.0",
     "@angular/core": "^20.0.0",
-    "@angular/platform-browser": "^20.0.0",
     "@angular/router": "^20.0.0",
     "@vitest/browser": "^2.1.0 || ^3.0.0 || ^4.0.0-0",
     "vitest": "^2.1.0 || ^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
-    "@analogjs/vite-plugin-angular": "^1.20.0",
-    "@analogjs/vitest-angular": "^1.20.0",
+    "@analogjs/vite-plugin-angular": "2.2.0",
+    "@analogjs/vitest-angular": "2.2.0",
     "@angular/compiler": "^20.3.0",
     "@angular/core": "^20.3.0",
     "@angular/platform-browser": "^20.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,11 +8,11 @@ importers:
   .:
     devDependencies:
       '@analogjs/vite-plugin-angular':
-        specifier: ^1.20.0
-        version: 1.22.1(@angular/build@20.3.0(@angular/compiler-cli@20.3.0(@angular/compiler@20.3.0)(typescript@5.9.2))(@angular/compiler@20.3.0)(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.0(@angular/common@20.3.0(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1)))(chokidar@4.0.3)(jiti@2.5.1)(postcss@8.5.6)(tslib@2.8.1)(tsx@4.20.5)(typescript@5.9.2)(vitest@4.0.8)(yaml@2.8.1))
+        specifier: 2.2.0
+        version: 2.2.0(@angular/build@20.3.0(@angular/compiler-cli@20.3.0(@angular/compiler@20.3.0)(typescript@5.9.2))(@angular/compiler@20.3.0)(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.0(@angular/common@20.3.0(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1)))(chokidar@4.0.3)(jiti@2.5.1)(postcss@8.5.6)(tslib@2.8.1)(tsx@4.20.5)(typescript@5.9.2)(vitest@4.0.8)(yaml@2.8.1))
       '@analogjs/vitest-angular':
-        specifier: ^1.20.0
-        version: 1.22.5(@analogjs/vite-plugin-angular@1.22.1(@angular/build@20.3.0(@angular/compiler-cli@20.3.0(@angular/compiler@20.3.0)(typescript@5.9.2))(@angular/compiler@20.3.0)(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.0(@angular/common@20.3.0(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1)))(chokidar@4.0.3)(jiti@2.5.1)(postcss@8.5.6)(tslib@2.8.1)(tsx@4.20.5)(typescript@5.9.2)(vitest@4.0.8)(yaml@2.8.1)))(@angular-devkit/architect@0.2100.2(chokidar@4.0.3))(vitest@4.0.8)
+        specifier: 2.2.0
+        version: 2.2.0(@analogjs/vite-plugin-angular@2.2.0(@angular/build@20.3.0(@angular/compiler-cli@20.3.0(@angular/compiler@20.3.0)(typescript@5.9.2))(@angular/compiler@20.3.0)(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.0(@angular/common@20.3.0(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1)))(chokidar@4.0.3)(jiti@2.5.1)(postcss@8.5.6)(tslib@2.8.1)(tsx@4.20.5)(typescript@5.9.2)(vitest@4.0.8)(yaml@2.8.1)))(@angular-devkit/architect@0.2100.2(chokidar@4.0.3))(vitest@4.0.8)
       '@angular/compiler':
         specifier: ^20.3.0
         version: 20.3.0
@@ -133,28 +133,28 @@ packages:
       }
     engines: { node: '>=6.0.0' }
 
-  '@analogjs/vite-plugin-angular@1.22.1':
+  '@analogjs/vite-plugin-angular@2.2.0':
     resolution:
       {
-        integrity: sha512-EAUctqpG/qRTXYnX7eLgMK2P1qN+FlA5ar2T07377YMQ8+lVdXVwAY5qZq54pvPLlnbXM1wfOaASzljTGNNslg==,
+        integrity: sha512-ujHfBb0V2MqUJN1Lji057TvM3Wxfi0ll6eo77BGpELN0UsjMspc35veQ2qWPCOscTGk5CI4+csXs0svQHDTekA==,
       }
     peerDependencies:
-      '@angular-devkit/build-angular': ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0
-      '@angular/build': ^18.0.0 || ^19.0.0 || ^20.0.0
+      '@angular-devkit/build-angular': ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0
+      '@angular/build': ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0
     peerDependenciesMeta:
       '@angular-devkit/build-angular':
         optional: true
       '@angular/build':
         optional: true
 
-  '@analogjs/vitest-angular@1.22.5':
+  '@analogjs/vitest-angular@2.2.0':
     resolution:
       {
-        integrity: sha512-lYwa9f6LFClW80sPhCydTOQvKnpWPnyChFhYdgMRpUZuKYo9102PndOLZkqR5K8WlKSilbP2293whaG1vZBMyA==,
+        integrity: sha512-IFLsxChJPL7noy9dksATL/L4ofIUbADdtaD0Taj5pSlGLZ7evmvG+Y71HUnJUyVcDWyfcNJpSnS8B16hmxAXgQ==,
       }
     peerDependencies:
       '@analogjs/vite-plugin-angular': '*'
-      '@angular-devkit/architect': '>=0.1500.0 < 0.2100.0'
+      '@angular-devkit/architect': '>=0.1500.0 < 0.2200.0'
       vitest: ^1.3.1 || ^2.0.0 || ^3.0.0 || ^4.0.0
 
   '@angular-devkit/architect@0.2003.0':
@@ -2131,12 +2131,6 @@ packages:
     resolution:
       {
         integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==,
-      }
-
-  '@types/unist@3.0.3':
-    resolution:
-      {
-        integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==,
       }
 
   '@typescript-eslint/eslint-plugin@8.42.0':
@@ -5100,12 +5094,6 @@ packages:
       }
     engines: { node: '>=18' }
 
-  unist-util-stringify-position@4.0.0:
-    resolution:
-      {
-        integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==,
-      }
-
   universal-user-agent@6.0.1:
     resolution:
       {
@@ -5167,18 +5155,6 @@ packages:
         integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==,
       }
     engines: { node: ^14.17.0 || ^16.13.0 || >=18.0.0 }
-
-  vfile-message@4.0.3:
-    resolution:
-      {
-        integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==,
-      }
-
-  vfile@6.0.3:
-    resolution:
-      {
-        integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==,
-      }
 
   vite@7.1.2:
     resolution:
@@ -5498,16 +5474,15 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.30
     optional: true
 
-  '@analogjs/vite-plugin-angular@1.22.1(@angular/build@20.3.0(@angular/compiler-cli@20.3.0(@angular/compiler@20.3.0)(typescript@5.9.2))(@angular/compiler@20.3.0)(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.0(@angular/common@20.3.0(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1)))(chokidar@4.0.3)(jiti@2.5.1)(postcss@8.5.6)(tslib@2.8.1)(tsx@4.20.5)(typescript@5.9.2)(vitest@4.0.8)(yaml@2.8.1))':
+  '@analogjs/vite-plugin-angular@2.2.0(@angular/build@20.3.0(@angular/compiler-cli@20.3.0(@angular/compiler@20.3.0)(typescript@5.9.2))(@angular/compiler@20.3.0)(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.0(@angular/common@20.3.0(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1)))(chokidar@4.0.3)(jiti@2.5.1)(postcss@8.5.6)(tslib@2.8.1)(tsx@4.20.5)(typescript@5.9.2)(vitest@4.0.8)(yaml@2.8.1))':
     dependencies:
       ts-morph: 21.0.1
-      vfile: 6.0.3
     optionalDependencies:
       '@angular/build': 20.3.0(@angular/compiler-cli@20.3.0(@angular/compiler@20.3.0)(typescript@5.9.2))(@angular/compiler@20.3.0)(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.0(@angular/common@20.3.0(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1)))(chokidar@4.0.3)(jiti@2.5.1)(postcss@8.5.6)(tslib@2.8.1)(tsx@4.20.5)(typescript@5.9.2)(vitest@4.0.8)(yaml@2.8.1)
 
-  '@analogjs/vitest-angular@1.22.5(@analogjs/vite-plugin-angular@1.22.1(@angular/build@20.3.0(@angular/compiler-cli@20.3.0(@angular/compiler@20.3.0)(typescript@5.9.2))(@angular/compiler@20.3.0)(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.0(@angular/common@20.3.0(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1)))(chokidar@4.0.3)(jiti@2.5.1)(postcss@8.5.6)(tslib@2.8.1)(tsx@4.20.5)(typescript@5.9.2)(vitest@4.0.8)(yaml@2.8.1)))(@angular-devkit/architect@0.2100.2(chokidar@4.0.3))(vitest@4.0.8)':
+  '@analogjs/vitest-angular@2.2.0(@analogjs/vite-plugin-angular@2.2.0(@angular/build@20.3.0(@angular/compiler-cli@20.3.0(@angular/compiler@20.3.0)(typescript@5.9.2))(@angular/compiler@20.3.0)(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.0(@angular/common@20.3.0(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1)))(chokidar@4.0.3)(jiti@2.5.1)(postcss@8.5.6)(tslib@2.8.1)(tsx@4.20.5)(typescript@5.9.2)(vitest@4.0.8)(yaml@2.8.1)))(@angular-devkit/architect@0.2100.2(chokidar@4.0.3))(vitest@4.0.8)':
     dependencies:
-      '@analogjs/vite-plugin-angular': 1.22.1(@angular/build@20.3.0(@angular/compiler-cli@20.3.0(@angular/compiler@20.3.0)(typescript@5.9.2))(@angular/compiler@20.3.0)(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.0(@angular/common@20.3.0(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1)))(chokidar@4.0.3)(jiti@2.5.1)(postcss@8.5.6)(tslib@2.8.1)(tsx@4.20.5)(typescript@5.9.2)(vitest@4.0.8)(yaml@2.8.1))
+      '@analogjs/vite-plugin-angular': 2.2.0(@angular/build@20.3.0(@angular/compiler-cli@20.3.0(@angular/compiler@20.3.0)(typescript@5.9.2))(@angular/compiler@20.3.0)(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.0(@angular/common@20.3.0(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.0(@angular/compiler@20.3.0)(rxjs@7.8.2)(zone.js@0.15.1)))(chokidar@4.0.3)(jiti@2.5.1)(postcss@8.5.6)(tslib@2.8.1)(tsx@4.20.5)(typescript@5.9.2)(vitest@4.0.8)(yaml@2.8.1))
       '@angular-devkit/architect': 0.2100.2(chokidar@4.0.3)
       vitest: 4.0.8(@types/debug@4.1.12)(@vitest/browser-playwright@4.0.8)(jiti@2.5.1)(sass@1.90.0)(tsx@4.20.5)(yaml@2.8.1)
 
@@ -6663,8 +6638,6 @@ snapshots:
     optional: true
 
   '@types/node@12.20.55': {}
-
-  '@types/unist@3.0.3': {}
 
   '@typescript-eslint/eslint-plugin@8.42.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
@@ -8521,10 +8494,6 @@ snapshots:
 
   unicorn-magic@0.3.0: {}
 
-  unist-util-stringify-position@4.0.0:
-    dependencies:
-      '@types/unist': 3.0.3
-
   universal-user-agent@6.0.1: {}
 
   universalify@0.1.2: {}
@@ -8550,16 +8519,6 @@ snapshots:
   url-join@5.0.0: {}
 
   validate-npm-package-name@5.0.1: {}
-
-  vfile-message@4.0.3:
-    dependencies:
-      '@types/unist': 3.0.3
-      unist-util-stringify-position: 4.0.0
-
-  vfile@6.0.3:
-    dependencies:
-      '@types/unist': 3.0.3
-      vfile-message: 4.0.3
 
   vite@7.1.2(jiti@2.5.1)(sass@1.90.0)(tsx@4.20.5)(yaml@2.8.1):
     dependencies:

--- a/src/pure.ts
+++ b/src/pure.ts
@@ -42,18 +42,18 @@ export interface RenderResult<T> {
   router?: Router;
 }
 
-export type RenderFn = <CMP_TYPE extends Type<unknown>>(
-  component: Type<CMP_TYPE>,
-  config?: RenderConfig<CMP_TYPE>,
-) => Promise<RenderResult<CMP_TYPE>>;
+export type RenderFn = <T>(
+  component: Type<T>,
+  config?: RenderConfig<Type<T>>,
+) => Promise<RenderResult<T>>;
 
-export async function render<CMP_TYPE extends Type<unknown>>(
-  componentClass: CMP_TYPE,
-  config?: RenderConfig<CMP_TYPE>,
-) {
+export async function render<T>(
+  componentClass: Type<T>,
+  config?: RenderConfig<Type<T>>,
+): Promise<RenderResult<T>> {
   const imports = [componentClass, ...(config?.imports || [])];
   const providers = [...(config?.providers || [])];
-  const renderResult: Partial<RenderResult<CMP_TYPE>> = {};
+  const renderResult: Partial<RenderResult<T>> = {};
 
   if (config?.withRouting) {
     const routes =
@@ -95,6 +95,6 @@ export async function render<CMP_TYPE extends Type<unknown>>(
   };
 }
 
-export function cleanup(shouldTearndown: boolean = false) {
-  return getCleanupHook(shouldTearndown)();
+export function cleanup(shouldTeardown = false) {
+  return getCleanupHook(shouldTeardown)();
 }

--- a/src/setup-zoneless.ts
+++ b/src/setup-zoneless.ts
@@ -1,6 +1,0 @@
-import "@angular/compiler";
-
-import "@analogjs/vitest-angular/setup-snapshots";
-import { setupAngularTestEnvironment } from "./setup";
-
-setupAngularTestEnvironment();

--- a/src/setup-zones.ts
+++ b/src/setup-zones.ts
@@ -1,3 +1,21 @@
+/**
+ * @deprecated This file is deprecated and will be removed in a future version.
+ *
+ * Please use @analogjs/vitest-angular's setupTestBed() instead with the browserMode: true option.
+ *
+ * See Analog's documentation for setup instructions:
+ * https://analogjs.org/docs/features/testing/vitest
+ *
+ * Important: Make sure to use { browserMode: true } when calling setupTestBed() to enable
+ * Vitest browser mode's visual test preview functionality.
+ */
+
+console.warn(
+  '[vitest-browser-angular] WARNING: The "vitest-browser-angular/setup-zones" setup file is deprecated and will be removed in a future version. ' +
+    "Please migrate to @analogjs/vitest-angular's setupTestBed() with { browserMode: true }. " +
+    "See: https://analogjs.org/docs/features/testing/vitest",
+);
+
 import "@angular/compiler";
 //
 import "@analogjs/vitest-angular/setup-zone";
@@ -5,7 +23,7 @@ import { TestBed } from "@angular/core/testing";
 import { beforeEach } from "vitest";
 import { setupAngularTestEnvironment } from "./setup";
 
-setupAngularTestEnvironment({ isZoneless: false });
+setupAngularTestEnvironment();
 // Register global beforeEach to reset TestBed between tests
 beforeEach(() => {
   TestBed.resetTestingModule();

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,5 +1,16 @@
-import { NgModule, provideZonelessChangeDetection } from "@angular/core";
-import { getTestBed, TestBed } from "@angular/core/testing";
+/**
+ * @deprecated This file is deprecated and will be removed in a future version.
+ *
+ * Please use @analogjs/vitest-angular's setupTestBed() instead with the browserMode: true option.
+ *
+ * See Analog's documentation for setup instructions:
+ * https://analogjs.org/docs/features/testing/vitest
+ *
+ * Important: Make sure to use { browserMode: true } when calling setupTestBed() to enable
+ * Vitest browser mode's visual test preview functionality.
+ */
+
+import { getTestBed } from "@angular/core/testing";
 import {
   BrowserTestingModule,
   platformBrowserTesting,
@@ -9,19 +20,9 @@ export type SetupOptions = {
   isZoneless: boolean;
 };
 
-export function setupAngularTestEnvironment(
-  options: SetupOptions = { isZoneless: true }, // Default to zoneless because from angular v21+ it is the default
-): void {
-  @NgModule({
-    providers: options.isZoneless ? [provideZonelessChangeDetection()] : [],
-  })
-  class ZonelessTestModule {}
-
-  if (TestBed.platform) {
-    return;
-  }
+export function setupAngularTestEnvironment(): void {
   getTestBed().initTestEnvironment(
-    [BrowserTestingModule, ...(options.isZoneless ? [ZonelessTestModule] : [])],
+    BrowserTestingModule,
     platformBrowserTesting(),
 
     // We need to set this in order for browser mode to keep showing the component after the test

--- a/test/vitest-zoneless-setup.ts
+++ b/test/vitest-zoneless-setup.ts
@@ -1,0 +1,8 @@
+import '@analogjs/vitest-angular/setup-snapshots';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+import '@angular/compiler';
+
+setupTestBed({
+  zoneless: true,
+  browserMode: true,
+});

--- a/test/vitest-zones-setup.ts
+++ b/test/vitest-zones-setup.ts
@@ -1,0 +1,9 @@
+import '@angular/compiler';
+//
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+import '@analogjs/vitest-angular/setup-zone';
+
+setupTestBed({
+  zoneless: false,
+  browserMode: true,
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
         extends: true,
         test: {
           name: { label: 'zone', color: 'red' },
-          setupFiles: ['./src/setup-zones.ts'],
+          setupFiles: ['./test/vitest-zones-setup.ts'],
           exclude: [...defaultExclude, '**/zoneless.test.ts'],
         },
       },
@@ -17,7 +17,7 @@ export default defineConfig({
         extends: true,
         test: {
           name: { label: 'zoneless', color: 'magenta' },
-          setupFiles: ['./src/setup-zoneless.ts'],
+          setupFiles: ['./test/vitest-zoneless-setup.ts'],
           include: ['**/zoneless.test.ts'],
         },
       },


### PR DESCRIPTION
## Summary

This PR deprecates the `vitest-browser-angular/setup-zones` and removes `vitest-browser-angular/setup-zoneless` setup files in favor of using `@analogjs/vitest-angular`'s `setupTestBed()` function directly. 

The deprecated files will be removed in a future major version.

The peerDependencies for analog/vitest and the angular compiler / platform-browser are removed as well. 

This PPR also fixes the render function component generic type.

## Motivation

Analog has implemented their own `setupTestBed()` function that provides a more comprehensive and maintained solution for setting up Angular tests with Vitest. 

Rather than maintaining duplicate setup logic and keeping documentation in sync, we're directing users to Analog's official documentation.

## Migration Guide

Users should migrate from:

```ts
// vitest.config.ts

setupFiles: ['vitest-browser-angular/setup-zones']
```

To using Analog's `setupTestBed()`:

```ts
setupTestBed({browserMode: true});
```

 See https://analogjs.org/docs/features/testing/vitest for full instructions
