### PR TITLE
Update API to align with vitest-browser ecosystem

### DIFF
--- a/.changeset/eleven-horses-thank.md
+++ b/.changeset/eleven-horses-thank.md
@@ -1,0 +1,7 @@
+---
+'vitest-browser-angular': minor
+---
+
+FEAT: renamed `RenderConfig` type to `ComponentRenderOptions`
+
+`RenderConfig` is now deprecated and will be removed in a future version. Use `ComponentRenderOptions` instead.`

--- a/.changeset/heavy-dragons-argue.md
+++ b/.changeset/heavy-dragons-argue.md
@@ -1,0 +1,16 @@
+---
+'vitest-browser-angular': minor
+---
+
+FEAT: return `container` element
+
+Now you can access the component's host element via the `container` property.
+This is basically a shortcut for `fixture.nativeElement`.
+
+```ts
+test('renders component with service provider', async () => {
+  const { container, fixture } = await render(HelloWorldComponent);
+
+  expect(container).toBe(fixture.nativeElement);
+});
+```

--- a/.changeset/itchy-eels-rule.md
+++ b/.changeset/itchy-eels-rule.md
@@ -1,0 +1,14 @@
+---
+'vitest-browser-angular': minor
+---
+
+FEAT: decorated render result with element locators (which start with the baseElement)
+
+Now you can do this:
+
+```ts
+test('renders component with service provider', async () => {
+  const screen = await render(HelloWorldComponent);
+  await expect.element(screen.getByText('Hello World')).toBeVisible(); // uses the baseElement as the root element for the query selector
+});
+```

--- a/.changeset/open-lemons-grab.md
+++ b/.changeset/open-lemons-grab.md
@@ -1,0 +1,8 @@
+---
+'vitest-browser-angular': minor
+---
+
+FEAT: add `baseElement`
+
+Now default locators will be based on the `baseElement` instead of the component element.
+This helps with testing components which project to a portal.

--- a/.changeset/plenty-comics-strive.md
+++ b/.changeset/plenty-comics-strive.md
@@ -1,0 +1,7 @@
+---
+'vitest-browser-angular': minor
+---
+
+FEAT: renamed `component` to `locator` to match other vitest-browser libraries api
+
+`component` is now deprecated and will be removed in a future version. Use `locator` instead.


### PR DESCRIPTION
This PR enhances the testing API with updated naming conventions and new features for querying elements.

### ✨ New Features

- **Render Result with Locator Methods**: The render result now includes built-in locator methods (`getByText`, `getByRole`, `getByLabelText`, etc.) that query from `baseElement` (defaults to `document.body`)
  
- **Container Element**: New `container` property provides direct access to the component's host element (shortcut for `fixture.nativeElement`)

- **Base Element Configuration**: New `baseElement` option allows customizing the root element for queries, essential for testing components with portals/overlays

### 🔄 Breaking Changes (with deprecation period)

- **`locator`** replaces `component` - Aligns with vitest-browser-vue and other libraries in the ecosystem
  - Old: `const { component } = await render(...)`
  - New: `const { locator } = await render(...)`
  - ⚠️ `component` is deprecated but still works for backward compatibility

- **`ComponentRenderOptions`** replaces `RenderConfig` type - More descriptive naming
  - ⚠️ `RenderConfig` is deprecated but still works for backward compatibility

### 📚 Documentation

- Comprehensive documentation updates with clear examples
- Explains when to use `locator` vs `screen` query patterns
- Examples updated to use the screen pattern where appropriate

---

**Migration**: All deprecated properties continue to work. Update at your convenience - simply rename `component` → `locator` and `RenderConfig` → `ComponentRenderOptions`.